### PR TITLE
Button margin fixed/ aligned to center.

### DIFF
--- a/client/src/styles/login.css
+++ b/client/src/styles/login.css
@@ -169,6 +169,8 @@
     font-size: 18px;
     font-weight: 600;
     border-radius: 5px;
+    margin: auto;
+    margin-top: 10px;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Fixed issue #104 
## before
<img width="502" alt="image" src="https://github.com/Open-Source-Chandigarh/Brewtopia/assets/108126089/7f3aa864-47da-4023-b9c1-6e52169cd05e">

## now
<img width="517" alt="image" src="https://github.com/Open-Source-Chandigarh/Brewtopia/assets/108126089/e3dc17b8-852c-447e-9db5-9443322f7005">
